### PR TITLE
Add sync protos job

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -1,0 +1,33 @@
+name: sync-protos
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours.
+
+
+jobs:
+  build:
+    name: Sync protos to clients
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clone inventory-api repo
+        run: git clone --depth=1 https://github.com/project-kessel/inventory-api.git
+      - name: Copy proto files
+        run: |
+
+          cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto protos/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto protos/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/authz/*.proto protos/kessel/inventory/v1beta1/
+          rm -rf inventory-api/
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Sync updated proto files'
+          title: Update protos
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# IDE
+.idea/
+.vscode/
+
 # C extensions
 *.so
 


### PR DESCRIPTION
Adds a job to the client that copies the v1beta1 protos from inventory-api