### PR TITLE
Proto ver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inventory-grpc-clients-python-kessel-project
-version = 0.10.4
+version = 0.10.5
 url = https://github.com/project-kessel/inventory-client-python
 author = Christopher Sams 
 author_email = "Christopher Sams" <csams@redhat.com>

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.8
 include_package_data = true
 install_requires =
     grpcio>=1.56.0
-    protobuf>=6.30.2
+    protobuf>=5.29.3
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Relax the protobuf version requirement. Its a bit too strict

## Summary by Sourcery

Relax the protobuf version requirement to allow for a broader range of compatible versions

Enhancements:
- Modify the protobuf version constraint to use a lower minimum version

Chores:
- Bump package version from 0.10.4 to 0.10.5