### PR TITLE
bump protobuf version to 6.30.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inventory-grpc-clients-python-kessel-project
-version = 0.10.7
+version = 0.10.8
 url = https://github.com/project-kessel/inventory-client-python
 author = Christopher Sams 
 author_email = "Christopher Sams" <csams@redhat.com>
@@ -23,7 +23,7 @@ python_requires = >=3.8
 include_package_data = true
 install_requires =
     grpcio>=1.56.0
-    protobuf>=5.29.3
+    protobuf>=6.30.2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
RE: https://protobuf.dev/support/cross-version-runtime-guarantee/

## Summary by Sourcery

Chores:
- Updated protobuf version in setup.cfg from 5.29.3 to 6.30.2